### PR TITLE
Flatpak: escape game path

### DIFF
--- a/Flatpak/firststart/src/main.c
+++ b/Flatpak/firststart/src/main.c
@@ -81,7 +81,7 @@ int main(int argc, char* argv[]) {
 		char *startupdir = gtk_file_chooser_get_filename(dirchooser);
 		if(startupdir != NULL) {
 			fputs("# Startup directory (for game browser)\n", file);
-			fprintf(file, "RPG_GAME_PATH=%s\n", startupdir);
+			fprintf(file, "RPG_GAME_PATH=\"%s\"\n", startupdir);
 			g_free(startupdir);
 		}
 


### PR DESCRIPTION
Currently, if a file path with e.g. spaces is set, the resulting flatpak.sh would break and the application won't start.

This PR escapes the game path that is set by the first start wizard.
Since the GTK file chooser will already sanitize paths to a degree, this should cover most common cases.
